### PR TITLE
PRIVATE INSTANCE VARIABLES & REMOVED GENERICS

### DIFF
--- a/ranjeetlibrary/src/main/java/ranjeet/library/RvAdapter.java
+++ b/ranjeetlibrary/src/main/java/ranjeet/library/RvAdapter.java
@@ -10,45 +10,45 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class RvAdapter<T> extends RecyclerView.Adapter {
+public abstract class RvAdapter extends RecyclerView.Adapter {
 
-    List<T> dataSet;
-    List<WeakReference<RecyclerView.ViewHolder>> holders;
+    private List<Object> dataSet;
+    private List<WeakReference<RecyclerView.ViewHolder>> holders;
 
-    public RvAdapter(List<T> dataSet){
+    public RvAdapter(List<Object> dataSet){
         this.holders = new ArrayList<>();
         this.dataSet = dataSet;
     }
 
-    public final void setDataSet(List<T> newDataSet){
-        List<T> oldDataSet = this.dataSet;
+    public final void setDataSet(List<Object> newDataSet){
+        List<Object> oldDataSet = this.dataSet;
         this.dataSet.clear();
         this.dataSet.addAll(newDataSet);
         dataSetChanged(oldDataSet, newDataSet);
     }
 
-    public final void setDataSet(List<T> newDataSet, DiffUtil.Callback diffUtilCallback){
+    public final void setDataSet(List<Object> newDataSet, DiffUtil.Callback diffUtilCallback){
         DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(diffUtilCallback);
         diffResult.dispatchUpdatesTo(this);
         this.dataSet.clear();
         this.dataSet.addAll(newDataSet);
     }
 
-    public final List<T> getDataSet(){
+    public final List<Object> getDataSet(){
         return new ArrayList<>(this.dataSet);
     }
 
-    public final void addData(T data){
+    public final void addData(Object data){
         this.dataSet.add(data);
         notifyItemInserted(this.dataSet.size()-1);
     }
 
-    public final void addData(int position, T data){
+    public final void addData(int position, Object data){
         this.dataSet.add(position, data);
         notifyItemInserted(position);
     }
 
-    public final void deleteData(T data){
+    public final void deleteData(Object data){
         int position = this.dataSet.indexOf(data);
         this.dataSet.remove(data);
         notifyItemRemoved(position);
@@ -59,12 +59,12 @@ public abstract class RvAdapter<T> extends RecyclerView.Adapter {
         notifyItemRemoved(position);
     }
 
-    public final void updateData(int position, T newData){
+    public final void updateData(int position, Object newData){
         this.dataSet.set(position, newData);
         notifyItemChanged(position);
     }
 
-    private void dataSetChanged(List<T> oldDataSet, List<T> newDataSet){
+    private void dataSetChanged(List<Object> oldDataSet, List<Object> newDataSet){
         int oldStart = getOldStart();
         int oldEnd = getOldEnd();
 


### PR DESCRIPTION
made dataSet and holders list private and also removed the generics because they where causing a unchecked type cast warning while getting the dataSet using getDataSet method.